### PR TITLE
add python 3.12 + removing 'v' + new support pip for rocky

### DIFF
--- a/docs/setup/conda.md
+++ b/docs/setup/conda.md
@@ -4,7 +4,7 @@ The Conda package installation guarantees optimal performance since it handles i
 
 ## Instructions
 
-We support :simple-python: **Python from 3.8 to 3.11**. If your current environment is compatible with this requirement, you can proceed as follows:
+We support :simple-python: **Python from 3.8 to 3.12**. If your current environment is compatible with this requirement, you can proceed as follows:
 
 === "Linux"
     ``` sh
@@ -23,7 +23,7 @@ We support :simple-python: **Python from 3.8 to 3.11**. If your current environm
 
 <br>
 
-If your default Conda environment uses a non-compatible Python version (e.g., Python 3.12) or if you need to use a specific python version for ensuring compatibility with other third-party packages, **you can create a new Conda environment for Khiops**, for example, with Python 3.8 (or any version from 3.8 to 3.11 that suits your needs). You can do so by using the command:
+If your default Conda environment uses a non-compatible Python version (e.g., Python 3.7) or if you need to use a specific python version for ensuring compatibility with other third-party packages, **you can create a new Conda environment for Khiops**, for example, with Python 3.8 (or any version from 3.8 to 3.12 that suits your needs). You can do so by using the command:
 
 ```sh
 conda create --name khiops_env python=3.8

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -25,7 +25,7 @@ Refer to the following table to select the appropriate installation method for y
 | :simple-linux: Ubuntu 20 and 22 (LTS)        | [:white_check_mark:][conda_page]  | [:white_check_mark:][pip_page]  | [:white_check_mark:][notebooks_page]  | [:white_check_mark:][nocode]  |
 | :simple-linux: Debian 10  | [:white_check_mark:][conda_page]  | [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  | [:white_check_mark:][nocode]  |
 | :simple-linux: Debian 11 and 12   | [:white_check_mark:][conda_page]  |   | [:white_check_mark:][notebooks_page]  |  |
-| :simple-linux: Rocky 9    | [:white_check_mark:][conda_page]  |  [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  |   |
+| :simple-linux: Rocky Linux 9    | [:white_check_mark:][conda_page]  |  [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  |   |
 
 The :simple-kaggle: **Kaggle Notebooks** and :simple-googlecolab: **Google Colaboratory** environments are supported. To benefit from Khiops on these environments, users are encouraged to install the Khiops :simple-anaconda: **Conda** package, which has been tested in these environments.
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -25,7 +25,7 @@ Refer to the following table to select the appropriate installation method for y
 | :simple-linux: Ubuntu 20 and 22 (LTS)        | [:white_check_mark:][conda_page]  | [:white_check_mark:][pip_page]  | [:white_check_mark:][notebooks_page]  | [:white_check_mark:][nocode]  |
 | :simple-linux: Debian 10  | [:white_check_mark:][conda_page]  | [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  | [:white_check_mark:][nocode]  |
 | :simple-linux: Debian 11 and 12   | [:white_check_mark:][conda_page]  |   | [:white_check_mark:][notebooks_page]  |  |
-| :simple-linux: Rocky Linux 8 and 9    | [:white_check_mark:][conda_page]  |  [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  |   |
+| :simple-linux: Rocky 9    | [:white_check_mark:][conda_page]  |  [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  |   |
 
 The :simple-kaggle: **Kaggle Notebooks** and :simple-googlecolab: **Google Colaboratory** environments are supported. To benefit from Khiops on these environments, users are encouraged to install the Khiops :simple-anaconda: **Conda** package, which has been tested in these environments.
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -16,7 +16,7 @@ Khiops supports a diversified set of installation options, to meet different nee
 
 <br>
 
-Refer to the following table to select the appropriate installation method for your operating system. <br>We support :simple-python: **Python from 3.8 to 3.11.**
+Refer to the following table to select the appropriate installation method for your operating system. <br>We support :simple-python: **Python from 3.8 to 3.12.**
 
 | OS | :simple-anaconda: Conda | Binary + :simple-python: pip | :simple-docker: Khiops-notebook |  :material-remote-desktop: Desktop app    |
 | ----------- | --------------------- | --------------------- | ----------------------- | -------------------------- |
@@ -25,7 +25,7 @@ Refer to the following table to select the appropriate installation method for y
 | :simple-linux: Ubuntu 20 and 22 (LTS)        | [:white_check_mark:][conda_page]  | [:white_check_mark:][pip_page]  | [:white_check_mark:][notebooks_page]  | [:white_check_mark:][nocode]  |
 | :simple-linux: Debian 10  | [:white_check_mark:][conda_page]  | [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  | [:white_check_mark:][nocode]  |
 | :simple-linux: Debian 11 and 12   | [:white_check_mark:][conda_page]  |   | [:white_check_mark:][notebooks_page]  |  |
-| :simple-linux: Rocky Linux 7 and 8    | [:white_check_mark:][conda_page]  |   | [:white_check_mark:][notebooks_page]  |   |
+| :simple-linux: Rocky Linux 8 and 9    | [:white_check_mark:][conda_page]  |  [:white_check_mark:][pip_page] | [:white_check_mark:][notebooks_page]  |   |
 
 The :simple-kaggle: **Kaggle Notebooks** and :simple-googlecolab: **Google Colaboratory** environments are supported. To benefit from Khiops on these environments, users are encouraged to install the Khiops :simple-anaconda: **Conda** package, which has been tested in these environments.
 
@@ -54,7 +54,7 @@ The Conda package contains all the necessary components.
     ``` sh
     conda install -c conda-forge -c khiops khiops
     ```
-**We support :simple-python: Python from 3.8 to 3.11**. If you are using a different version of Python in your current environment, we recommend visiting our Conda Installation Page for instructions on creating a new environment tailored for Khiops:
+**We support :simple-python: Python from 3.8 to 3.12**. If you are using a different version of Python in your current environment, we recommend visiting our Conda Installation Page for instructions on creating a new environment tailored for Khiops:
 
 [:material-cursor-default-click-outline: See the Conda Installation Page](conda.md){ .md-button .md-button--primary }
 
@@ -82,7 +82,7 @@ This version contains a standalone Graphical User Interface (GUI).
 === "Windows"
     The :material-microsoft-windows: Khiops installer automatically installs the Khiops desktop application, all its dependencies, plus the Khiops samples and the Khiops Visualization application:
 
-    <a href="https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops-10.2.0-setup.exe">
+    <a href="https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-10.2.0-setup.exe">
         <button class="btn btn-light btn-sm">
           Download for Windows
         </button>
@@ -94,8 +94,8 @@ This version contains a standalone Graphical User Interface (GUI).
     CODENAME=$(lsb_release -cs) && \
     TEMP_DEB_CORE="$(mktemp)" && \
     TEMP_DEB_KHIOPS="$(mktemp)" && \
-    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops-core_10.2.0-1-${CODENAME}.amd64.deb" && \
-    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops_10.2.0-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-core_10.2.0-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops_10.2.0-1-${CODENAME}.amd64.deb" && \
     sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
     ```

--- a/docs/setup/nocode.md
+++ b/docs/setup/nocode.md
@@ -45,7 +45,7 @@ To get started with the Khiops desktop application, follow the relevant procedur
     If you need the Khiops samples, you can run the following commands:
     ```sh
     TEMP_SAMPLES="$(mktemp)" && \
-    wget -O "$TEMP_SAMPLES" "https://github.com/KhiopsML/khiops-samples/releases/download/10.2.0/khiops-samples-v10.2.0.zip" && \
+    wget -O "$TEMP_SAMPLES" "https://github.com/KhiopsML/khiops-samples/releases/download/v10.2.0/khiops-samples-v10.2.0.zip" && \
     mkdir -p ~/khiops_data/samples && \
     unzip "$TEMP_SAMPLES" -d ~/khiops_data/samples && \
     rm -f $TEMP_SAMPLES

--- a/docs/setup/nocode.md
+++ b/docs/setup/nocode.md
@@ -18,7 +18,7 @@ To get started with the Khiops desktop application, follow the relevant procedur
 === "Windows"
     The :material-microsoft-windows: Khiops installer automatically installs the Khiops desktop application, all its dependencies, plus some data samples formatted as expected by Khiops, and the Khiops Visualization application.
 
-    <a href="https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops-10.2.0-setup.exe">
+    <a href="https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-10.2.0-setup.exe">
         <button class="btn btn-light btn-sm">
           Download for Windows
         </button>
@@ -36,8 +36,8 @@ To get started with the Khiops desktop application, follow the relevant procedur
     CODENAME=$(lsb_release -cs) && \
     TEMP_DEB_CORE="$(mktemp)" && \
     TEMP_DEB_KHIOPS="$(mktemp)" && \
-    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops-core_10.2.0-1-${CODENAME}.amd64.deb" && \
-    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops_10.2.0-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-core_10.2.0-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops_10.2.0-1-${CODENAME}.amd64.deb" && \
     sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
     ```
@@ -45,7 +45,7 @@ To get started with the Khiops desktop application, follow the relevant procedur
     If you need the Khiops samples, you can run the following commands:
     ```sh
     TEMP_SAMPLES="$(mktemp)" && \
-    wget -O "$TEMP_SAMPLES" "https://github.com/KhiopsML/khiops-samples/releases/download/v10.2.0/khiops-samples-v10.2.0.zip" && \
+    wget -O "$TEMP_SAMPLES" "https://github.com/KhiopsML/khiops-samples/releases/download/10.2.0/khiops-samples-v10.2.0.zip" && \
     mkdir -p ~/khiops_data/samples && \
     unzip "$TEMP_SAMPLES" -d ~/khiops_data/samples && \
     rm -f $TEMP_SAMPLES

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -6,7 +6,7 @@ The Khiops binaries must be installed as a prerequisite. This also ensures the i
 
 We support :simple-python: **Python from 3.8 to 3.12**. 
 
-=== "Ubuntu/Debian"
+=== "Ubuntu 20-22 / Debian 10"
     
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh
@@ -34,7 +34,7 @@ We support :simple-python: **Python from 3.8 to 3.12**.
     pip install "https://github.com/KhiopsML/khiops-python/releases/download/10.2.0.0/khiops-10.2.0.0.tar.gz"
     ```
 
-=== "Rocky Linux"
+=== "Rocky 9"
     
     You need to download and install the `khiops-core` package (via Yum) and then the Khiops library (via Pip). You can do this through the following command:
     ``` sh

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -10,7 +10,6 @@ We support :simple-python: **Python from 3.8 to 3.12**.
     
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh
-    # Install pre-requisites (if not already installed on the host system)
     sudo apt-get update -y && sudo apt-get install wget lsb-release -y && \
     CODENAME=$(lsb_release -cs) && \
     TEMP_DEB="$(mktemp)" && \
@@ -39,7 +38,6 @@ We support :simple-python: **Python from 3.8 to 3.12**.
     
     You need to download and install the `khiops-core` package (via Yum) and then the Khiops library (via Pip). You can do this through the following command:
     ``` sh
-    # Install pre-requisites (if not already installed on the host system)
     sudo yum update -y && sudo yum install wget python3-pip -y && \
     CENTOS_VERSION=$(rpm -E %{rhel}) && \
     TEMP_RPM="$(mktemp).rpm" && \

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -34,7 +34,7 @@ We support :simple-python: **Python from 3.8 to 3.12**.
     pip install "https://github.com/KhiopsML/khiops-python/releases/download/10.2.0.0/khiops-10.2.0.0.tar.gz"
     ```
 
-=== "Rocky 9"
+=== "Rocky Linux 9"
     
     You need to download and install the `khiops-core` package (via Yum) and then the Khiops library (via Pip). You can do this through the following command:
     ``` sh

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -4,7 +4,7 @@ Opting for `pip` is ideal for those with a comprehensive grasp of Python's ecosy
 
 The Khiops binaries must be installed as a prerequisite. This also ensures the installation of the appropriate version of `MPICH` library.
 
-We support :simple-python: **Python from 3.8 to 3.11**. 
+We support :simple-python: **Python from 3.8 to 3.12**. 
 
 === "Ubuntu/Debian"
     
@@ -12,17 +12,17 @@ We support :simple-python: **Python from 3.8 to 3.11**.
     ``` sh
     CODENAME=$(lsb_release -cs) && \
     TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops-core_10.2.0-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-core_10.2.0-1-${CODENAME}.amd64.deb" && \
     sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB && \
-    pip install 'https://github.com/KhiopsML/khiops-python/releases/download/v10.2.0.0/khiops-10.2.0.0.tar.gz'
+    pip install 'https://github.com/KhiopsML/khiops-python/releases/download/10.2.0.0/khiops-10.2.0.0.tar.gz'
     ```
 
 
 === "Windows"
     You need to download and install the Khiops desktop application first:
 
-    <a href="https://github.com/KhiopsML/khiops/releases/download/v10.2.0/khiops-10.2.0-setup.exe">
+    <a href="https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-10.2.0-setup.exe">
         <button class="btn btn-light btn-sm">
           Download for Windows
         </button>
@@ -30,9 +30,20 @@ We support :simple-python: **Python from 3.8 to 3.11**.
 
     Then, you can run the following Pip command:
     ```sh
-    pip install "https://github.com/KhiopsML/khiops-python/releases/download/v10.2.0.0/khiops-10.2.0.0.tar.gz"
+    pip install "https://github.com/KhiopsML/khiops-python/releases/download/10.2.0.0/khiops-10.2.0.0.tar.gz"
     ```
 
+=== "Rocky Linux"
+    
+    You need to download and install the `khiops-core` package (via Yum) and then the Khiops library (via Pip). You can do this through the following command:
+    ``` sh
+    CENTOS_VERSION=$(rpm -E %{rhel}) && \
+    TEMP_RPM="$(mktemp).rpm" && \
+    wget -O "$TEMP_RPM" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-core-10.2.0-1.el${CENTOS_VERSION}.x86_64.rpm" && \
+    sudo yum install "$TEMP_RPM" -y && \
+    rm -f $TEMP_RPM && \
+    pip install 'https://github.com/KhiopsML/khiops-python/releases/download/10.2.0.0/khiops-10.2.0.0.tar.gz'
+    ```
 
 
 ## User Guide

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -6,7 +6,7 @@ The Khiops binaries must be installed as a prerequisite. This also ensures the i
 
 We support :simple-python: **Python from 3.8 to 3.12**. 
 
-=== "Ubuntu 20-22 / Debian 10"
+=== "Ubuntu 20,22 / Debian 10"
     
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -6,7 +6,7 @@ The Khiops binaries must be installed as a prerequisite. This also ensures the i
 
 We support :simple-python: **Python from 3.8 to 3.12**. 
 
-=== "Ubuntu 20,22 / Debian 10"
+=== "Ubuntu 20, 22 / Debian 10"
     
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -10,6 +10,8 @@ We support :simple-python: **Python from 3.8 to 3.12**.
     
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh
+    # Install pre-requisites (if not already installed on the host system)
+    sudo apt-get update -y && sudo apt-get install wget lsb-release -y && \
     CODENAME=$(lsb_release -cs) && \
     TEMP_DEB="$(mktemp)" && \
     wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-core_10.2.0-1-${CODENAME}.amd64.deb" && \
@@ -37,6 +39,8 @@ We support :simple-python: **Python from 3.8 to 3.12**.
     
     You need to download and install the `khiops-core` package (via Yum) and then the Khiops library (via Pip). You can do this through the following command:
     ``` sh
+    # Install pre-requisites (if not already installed on the host system)
+    sudo yum update -y && sudo yum install wget python3-pip -y && \
     CENTOS_VERSION=$(rpm -E %{rhel}) && \
     TEMP_RPM="$(mktemp).rpm" && \
     wget -O "$TEMP_RPM" "https://github.com/KhiopsML/khiops/releases/download/10.2.0/khiops-core-10.2.0-1.el${CENTOS_VERSION}.x86_64.rpm" && \


### PR DESCRIPTION
Based on the recent test outcomes, I have implemented the following updates:
- Official support for Python 3.12 has been introduced.
- The "binary + pip" installation option is now available for Rocky 8 and 9, as reflected in the updated table.
- All URLs have been revised, changing from '/v10.2.0/' to '/10.2.0/'.
- The installation process for Rocky has been detailed and added to the 'pip' dedicated page.