### PR TITLE
Update pip.md

### DIFF
--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -27,7 +27,7 @@ We support :simple-python: **Python from 3.8 to 3.13**.
 
 === "Windows"
     
-    The Khiops binaries, required for the library to operate, are included in the Khiops Application. Therefore, **you must download and install the desktop application before executing the `pip` installation command**:
+    The Khiops binaries, required for the Python library to operate, are included in the Khiops Application. Therefore, **you must download and install the desktop application before executing the `pip` installation command**:
 
     <a href="https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-{{ KHIOPS_VERSION }}-setup.exe">
         <button class="btn btn-light btn-sm">

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -26,7 +26,8 @@ We support :simple-python: **Python from 3.8 to 3.13**.
 
 
 === "Windows"
-    You need to download and install the Khiops desktop application first:
+    
+    The Khiops binaries, required for the library to operate, are included in the Khiops Application. Therefore, **you must download and install the desktop application before executing the `pip` installation command**:
 
     <a href="https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-{{ KHIOPS_VERSION }}-setup.exe">
         <button class="btn btn-light btn-sm">

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -27,7 +27,7 @@ We support :simple-python: **Python from 3.8 to 3.13**.
 
 === "Windows"
     
-    The Khiops binaries, required for the Python library to operate, are included in the Khiops Application. Therefore, **you must download and install the desktop application before executing the `pip` installation command**:
+    To install the Khiops binaries, required for the Khiops Python library to operate, you must first install the Khiops application before executing the `pip` installation command:
 
     <a href="https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-{{ KHIOPS_VERSION }}-setup.exe">
         <button class="btn btn-light btn-sm">


### PR DESCRIPTION
This update clarifies the installation requirements for Khiops when using the pip method. The previous phrase was potentially ambiguous for Windows. It has been rephrased to explicitly state that the Khiops binaries, essential for the library to function, are included in the desktop application and must be installed before running the pip command.