### PR TITLE
Invariance to monotonic transformations

### DIFF
--- a/docs/learn/preprocessing.md
+++ b/docs/learn/preprocessing.md
@@ -227,4 +227,6 @@ For an efficient coding, it is necessary to keep in memory the sorted lists of a
 !!! tip "Data Cleaning Not Required"
     Khiops eliminates the need for cleaning your training data, and even discourages it to avoid introducing bias into the data. The library incorporates the missing values as predictive features rather than discarding them. In the case of discretization models, missing values are treated as an extreme value, while for modality grouping models, they are treated as a distinct modality. This enables the model to capture informative patterns the missing values might offer for classifying the target variable. During inference, any unknown modalities encountered are automatically categorized as missing values.
    
-
+!!! tip "Invariance to Monotonic Transformations"
+    **Khiops’ discretization is based on value ranks**, meaning it is invariant to any monotonic transformation (log, square root, square, exponential, etc.). Whether a numerical feature is directly used or transformed, the resulting discretization remains **unchanged**.
+    As a result, **users do not need to apply transformations like log-scaling or standardization**.

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -33,7 +33,7 @@ Whether you’re exploring Khiops for rapid prototyping or integrating it into l
 Khiops introduces a streamlined and effective approach to data science, **simplifying every stage of the process** while providing advanced automation and a robust formalism. Unlike traditional tools, Khiops enables you **to focus on what truly matters**: understanding your data, interpreting insights (the story your data tells), solving business problems, and deploying reliable models. Here's how you can leverage Khiops' unique features step by step:
 
 
-- **Skip Data Cleaning and Preparation**: Forget about spending hours on cleaning and formatting your data. Khiops reads raw data directly and handles common issues like missing values, inconsistent formats, or noisy inputs. For example, if your dataset contains missing values, Khiops automatically treats them as meaningful signals when training models. It also removes the need for transformations like log scaling or standardization, as its value ranks based encoding is inherently invariant to monotonic transformations.
+- **Skip Data Cleaning and Preparation**: Forget about spending hours on cleaning and formatting your data. Khiops reads raw data directly and handles common issues like missing values, inconsistent formats, or noisy inputs. For example, if your dataset contains missing values, Khiops automatically treats them as meaningful signals when training models. It also removes the need for transformations like log scaling or standardization, as its value rank-based encoding is inherently invariant to monotonic transformations.
 
     !!! example "Follow the [**No Need for Data Preparation**][no_data_cleaning] tutorial to see this in action."
 

--- a/docs/tutorials/introduction.md
+++ b/docs/tutorials/introduction.md
@@ -32,7 +32,8 @@ Whether you’re exploring Khiops for rapid prototyping or integrating it into l
 
 Khiops introduces a streamlined and effective approach to data science, **simplifying every stage of the process** while providing advanced automation and a robust formalism. Unlike traditional tools, Khiops enables you **to focus on what truly matters**: understanding your data, interpreting insights (the story your data tells), solving business problems, and deploying reliable models. Here's how you can leverage Khiops' unique features step by step:
 
-- **Skip Data Cleaning**: Forget about spending hours on cleaning and formatting your data. Khiops reads raw data directly and handles common issues like missing values, inconsistent formats, or noisy inputs. For example, if your dataset contains missing values, Khiops automatically treats them as meaningful signals when training models.
+
+- **Skip Data Cleaning and Preparation**: Forget about spending hours on cleaning and formatting your data. Khiops reads raw data directly and handles common issues like missing values, inconsistent formats, or noisy inputs. For example, if your dataset contains missing values, Khiops automatically treats them as meaningful signals when training models. It also removes the need for transformations like log scaling or standardization, as its value ranks based encoding is inherently invariant to monotonic transformations.
 
     !!! example "Follow the [**No Need for Data Preparation**][no_data_cleaning] tutorial to see this in action."
 


### PR DESCRIPTION
This PR updates the documentation to explicitly mention Khiops’ invariance to monotonic transformations (e.g., log scaling, standardization) thanks to its value ranks based encoding.

This is done in two pages:

**1 - Getting Started (How to) – Skip Data Cleaning and Preparation:** Added a sentence clarifying that Khiops removes the need for transformations like log scaling or standardization.

**2 - Optimal Encoding Page (Foundations):** Introduced a new section "Invariance to Monotonic Transformations".
