### PR TITLE
Fix URI to the Python API documentation

### DIFF
--- a/overrides/python-api.html
+++ b/overrides/python-api.html
@@ -4,7 +4,7 @@
 
 <section style="width: 100vw;">
     <div >
-    <iframe src="https://khiopsml.github.io/khiops-python/index.html" style="width: 100%;height: 100vh;"></iframe>
+        <iframe src="{{ config.extra.KHIOPS_PYTHON_API_DOC_URI }}" style="width: 100%;height: 100vh;"></iframe>
     </div>
 </section>
 


### PR DESCRIPTION
Make it customizable via Mkdocs config variable.