### PR TITLE
Back to dpkg to install deb packages

### DIFF
--- a/docs/setup/nocode.md
+++ b/docs/setup/nocode.md
@@ -41,11 +41,12 @@ For further details, you may refer to [README.txt][readme], and [WHATSNEW.txt][w
     You can install both packages as follows:
 
     ``` sh
-    CODENAME=$(lsb_release -cs) && \
+    sudo apt-get update -y && sudo apt-get install wget -y && \
+    source /etc/os-release && \
     TEMP_DEB_CORE="$(mktemp)" && \
     TEMP_DEB_KHIOPS="$(mktemp)" && \
-    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.amd64.deb" && \
-    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.amd64.deb" && \
     sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
     ```
@@ -74,11 +75,12 @@ For further details, you may refer to [README.txt][readme], and [WHATSNEW.txt][w
     You can install both packages as follows:
 
     ``` sh
-    CODENAME=$(lsb_release -cs) && \
+    sudo apt-get update -y && sudo apt-get install wget -y && \
+    source /etc/os-release && \
     TEMP_DEB_CORE="$(mktemp)" && \
     TEMP_DEB_KHIOPS="$(mktemp)" && \
-    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.arm64.deb" && \
-    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${CODENAME}.arm64.deb" && \
+    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.arm64.deb" && \
+    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.arm64.deb" && \
     sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
     ```

--- a/docs/setup/nocode.md
+++ b/docs/setup/nocode.md
@@ -30,7 +30,7 @@ For further details, you may refer to [README.txt][readme], and [WHATSNEW.txt][w
         </button>
     </a>
 
-=== "Ubuntu / Debian on x86-64 architectures"
+=== "Ubuntu / Debian (ARM and x86)"
     The installation of the Khiops desktop application involves two packages:
 
      - `khiops-core`: This is a lightweight package without GUI, documentation or samples. It is intended to be used in advanced settings, on servers and Docker images.
@@ -43,44 +43,11 @@ For further details, you may refer to [README.txt][readme], and [WHATSNEW.txt][w
     ``` sh
     sudo apt-get update -y && sudo apt-get install wget -y && \
     source /etc/os-release && \
+    ARCH=$(dpkg --print-architecture) && \
     TEMP_DEB_CORE="$(mktemp)" && \
     TEMP_DEB_KHIOPS="$(mktemp)" && \
-    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.amd64.deb" && \
-    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.amd64.deb" && \
-    sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
-    rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
-    ```
-
-    If you need the Khiops samples, you can download them from 
-    <a href="https://github.com/KhiopsML/khiops-samples/releases/download/{{ KHIOPS_SAMPLES_VERSION }}/khiops-samples-{{ KHIOPS_SAMPLES_VERSION }}.zip        ">
-    here</a>, or you can run the following commands:
-    ```sh
-    TEMP_SAMPLES="$(mktemp)" && \
-    wget -O "$TEMP_SAMPLES" "https://github.com/KhiopsML/khiops-samples/releases/download/{{ KHIOPS_SAMPLES_VERSION }}/khiops-samples-{{ KHIOPS_SAMPLES_VERSION }}.zip" && \
-    mkdir -p ~/khiops_data/samples && \
-    unzip "$TEMP_SAMPLES" -d ~/khiops_data/samples && \
-    rm -f $TEMP_SAMPLES
-    ```
-
-    !!! info "Currently, our packages are released on GitHub. In the coming weeks, we will transition to official repositories."
-
-=== "Ubuntu / Debian on ARM architectures"
-    The installation of the Khiops desktop application involves two packages:
-
-     - `khiops-core`: This is a lightweight package without GUI, documentation or samples. It is intended to be used in advanced settings, on servers and Docker images.
-     - `khiops`: This package requires `khiops-core` and is the full version of Khiops containing the GUI and the documentation.
-
-    Unlike the Windows installer, **the Khiops Visualization application is not included.**
-
-    You can install both packages as follows:
-
-    ``` sh
-    sudo apt-get update -y && sudo apt-get install wget -y && \
-    source /etc/os-release && \
-    TEMP_DEB_CORE="$(mktemp)" && \
-    TEMP_DEB_KHIOPS="$(mktemp)" && \
-    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.arm64.deb" && \
-    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.arm64.deb" && \
+    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.${ARCH}.deb" && \
+    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.${ARCH}.deb" && \
     sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
     ```

--- a/docs/setup/nocode.md
+++ b/docs/setup/nocode.md
@@ -30,7 +30,7 @@ For further details, you may refer to [README.txt][readme], and [WHATSNEW.txt][w
         </button>
     </a>
 
-=== "Ubuntu / Debian"
+=== "Ubuntu / Debian on x86-64 architectures"
     The installation of the Khiops desktop application involves two packages:
 
      - `khiops-core`: This is a lightweight package without GUI, documentation or samples. It is intended to be used in advanced settings, on servers and Docker images.
@@ -38,17 +38,49 @@ For further details, you may refer to [README.txt][readme], and [WHATSNEW.txt][w
 
     Unlike the Windows installer, **the Khiops Visualization application is not included.**
 
-    You can install both packages by using the Khiops PPA hosted on GitHub,
-    as follows:
+    You can install both packages as follows:
 
     ``` sh
-    curl -s --compressed "https://khiopsml.github.io/Khiops-PPA/ubuntu/KEY.gpg" \
-      | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/khiops.gpg >/dev/null
-    sudo echo "deb [signed-by=/etc/apt/trusted.gpg.d/khiops.gpg] \
-      https://khiopsml.github.io/Khiops-PPA/ubuntu ./" \
-      > /etc/apt/sources.list.d/khiops.list
-    sudo apt-get update
-    sudo apt-get install khiops={{ KHIOPS_VERSION }}
+    CODENAME=$(lsb_release -cs) && \
+    TEMP_DEB_CORE="$(mktemp)" && \
+    TEMP_DEB_KHIOPS="$(mktemp)" && \
+    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${CODENAME}.amd64.deb" && \
+    sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
+    rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
+    ```
+
+    If you need the Khiops samples, you can download them from 
+    <a href="https://github.com/KhiopsML/khiops-samples/releases/download/{{ KHIOPS_SAMPLES_VERSION }}/khiops-samples-{{ KHIOPS_SAMPLES_VERSION }}.zip        ">
+    here</a>, or you can run the following commands:
+    ```sh
+    TEMP_SAMPLES="$(mktemp)" && \
+    wget -O "$TEMP_SAMPLES" "https://github.com/KhiopsML/khiops-samples/releases/download/{{ KHIOPS_SAMPLES_VERSION }}/khiops-samples-{{ KHIOPS_SAMPLES_VERSION }}.zip" && \
+    mkdir -p ~/khiops_data/samples && \
+    unzip "$TEMP_SAMPLES" -d ~/khiops_data/samples && \
+    rm -f $TEMP_SAMPLES
+    ```
+
+    !!! info "Currently, our packages are released on GitHub. In the coming weeks, we will transition to official repositories."
+
+=== "Ubuntu / Debian on ARM architectures"
+    The installation of the Khiops desktop application involves two packages:
+
+     - `khiops-core`: This is a lightweight package without GUI, documentation or samples. It is intended to be used in advanced settings, on servers and Docker images.
+     - `khiops`: This package requires `khiops-core` and is the full version of Khiops containing the GUI and the documentation.
+
+    Unlike the Windows installer, **the Khiops Visualization application is not included.**
+
+    You can install both packages as follows:
+
+    ``` sh
+    CODENAME=$(lsb_release -cs) && \
+    TEMP_DEB_CORE="$(mktemp)" && \
+    TEMP_DEB_KHIOPS="$(mktemp)" && \
+    wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.arm64.deb" && \
+    wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${CODENAME}.arm64.deb" && \
+    sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
+    rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
     ```
 
     If you need the Khiops samples, you can download them from 

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -12,27 +12,15 @@ The Khiops executables must be installed as a prerequisite. This also ensures th
 We support :simple-python: **Python from 3.10 to 3.14**. Usage of previous
 versions of Python can be attempted, but there is no support for it.
 
-=== "Ubuntu / Debian on x86-64 architectures"
+=== "Ubuntu / Debian (ARM and x86)"
 
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh
     sudo apt-get update -y && sudo apt-get install wget -y && \
     source /etc/os-release && \
+    ARCH=$(dpkg --print-architecture)
     TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.amd64.deb" && \
-    sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
-    rm -f $TEMP_DEB && \
-    pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}
-    ```
-
-=== "Ubuntu / Debian on ARM architectures"
-
-    You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
-    ``` sh
-    sudo apt-get update -y && sudo apt-get install wget -y && \
-    source /etc/os-release && \
-    TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.arm64.deb" && \
+    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.${ARCH}.deb" && \
     sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB && \
     pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -12,17 +12,29 @@ The Khiops executables must be installed as a prerequisite. This also ensures th
 We support :simple-python: **Python from 3.10 to 3.14**. Usage of previous
 versions of Python can be attempted, but there is no support for it.
 
-=== "Ubuntu / Debian"
+=== "Ubuntu / Debian on x86-64 architectures"
 
-    You need to install the `khiops-core` package (via Apt) from the Khiops PPA hosted on GitHub, and then the Khiops library (via Pip). You can do this through the following shell commands:
+    You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh
-    curl -s --compressed "https://khiopsml.github.io/Khiops-PPA/ubuntu/KEY.gpg" \
-      | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/khiops.gpg >/dev/null
-    sudo echo "deb [signed-by=/etc/apt/trusted.gpg.d/khiops.gpg] \
-      https://khiopsml.github.io/Khiops-PPA/ubuntu ./" \
-      > /etc/apt/sources.list.d/khiops.list
-    sudo apt-get update
-    sudo apt-get install khiops-core-openmpi={{ KHIOPS_VERSION }}
+    sudo apt-get update -y && sudo apt-get install wget lsb-release -y && \
+    CODENAME=$(lsb_release -cs) && \
+    TEMP_DEB="$(mktemp)" && \
+    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.amd64.deb" && \
+    sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
+    rm -f $TEMP_DEB && \
+    pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}
+    ```
+
+=== "Ubuntu / Debian on ARM architectures"
+
+    You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
+    ``` sh
+    sudo apt-get update -y && sudo apt-get install wget lsb-release -y && \
+    CODENAME=$(lsb_release -cs) && \
+    TEMP_DEB="$(mktemp)" && \
+    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.arm64.deb" && \
+    sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
+    rm -f $TEMP_DEB && \
     pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}
     ```
 

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -16,10 +16,10 @@ versions of Python can be attempted, but there is no support for it.
 
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh
-    sudo apt-get update -y && sudo apt-get install wget lsb-release -y && \
-    CODENAME=$(lsb_release -cs) && \
+    sudo apt-get update -y && sudo apt-get install wget -y && \
+    source /etc/os-release && \
     TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.amd64.deb" && \
+    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.amd64.deb" && \
     sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB && \
     pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}
@@ -29,10 +29,10 @@ versions of Python can be attempted, but there is no support for it.
 
     You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
     ``` sh
-    sudo apt-get update -y && sudo apt-get install wget lsb-release -y && \
-    CODENAME=$(lsb_release -cs) && \
+    sudo apt-get update -y && sudo apt-get install wget -y && \
+    source /etc/os-release && \
     TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${CODENAME}.arm64.deb" && \
+    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.arm64.deb" && \
     sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
     rm -f $TEMP_DEB && \
     pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}


### PR DESCRIPTION
I switched to:
```sh
source /etc/os-release
TEMP_DEB_CORE="$(mktemp)" && \
TEMP_DEB_KHIOPS="$(mktemp)" && \
ARCH=$(dpkg --print-architecture) && \
wget -O "$TEMP_DEB_CORE" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.${ARCH}.deb" && \
wget -O "$TEMP_DEB_KHIOPS" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.${ARCH}.deb" && \
sudo dpkg -i "$TEMP_DEB_CORE" "$TEMP_DEB_KHIOPS" || sudo apt-get -f -y install && \
rm -f $TEMP_DEB_CORE $TEMP_DEB_KHIOPS
```