### PR TITLE
Minor corrections in derivation rules and documentation

### DIFF
--- a/docs/api-docs/kdic/date-rules.md
+++ b/docs/api-docs/kdic/date-rules.md
@@ -1,7 +1,9 @@
 # Date Rules
 
-`Date` values are encoded in data table files using Khiops native format `YYYY-MM-DD`. Other formats
-are available, that allow to convert categorical values to date values.
+`Date` values are encoded in data table files using Khiops native format `YYYY-MM-DD`, or an alternative format specified by the
+`DateFormat` meta-data (see [`Meta-data`](../kdic/dictionary-files.md/#meta-data)).
+
+All available formats are described below:
 
 |              |              |              |            |
 | ------------ | ------------ | ------------ | ---------- |

--- a/docs/api-docs/kdic/hash-map-rules.md
+++ b/docs/api-docs/kdic/hash-map-rules.md
@@ -1,6 +1,6 @@
 # Hash Map Rules
 
-## Structure
+## HashMapC
 
 ```kdic-api-docs
 Structure(HashMapC) HashMapC(Structure(VectorC) keyVector, Structure(VectorC) valueVector)

--- a/docs/api-docs/kdic/table-management-rules.md
+++ b/docs/api-docs/kdic/table-management-rules.md
@@ -76,6 +76,7 @@ Entity TableAtKey(Table table, Categorical keyField1, Categorical keyField2, ...
 
 Extraction of an entity of a table at a given key. The number of key fields must match that of the
 dictionary of the table.
+Returns the first entity in the table that matches the input key. If no entity is found, it returns nothing.
 
 ## TableExtraction
 
@@ -249,7 +250,7 @@ Table EntitySet(Entity entity1, Entity entity2, ...)
 
 Builds a table from a set of entities. All the entities in the operands must have the same
 `Dictionary` definition; the result table will also have the same `Dictionary` definition.
-
+Duplicate or missing entities are ignored, ensuring that the resulting table contains only distinct, existing entities.
 
 !!! example
 

--- a/docs/api-docs/kdic/text-rules.md
+++ b/docs/api-docs/kdic/text-rules.md
@@ -48,6 +48,7 @@ Numerical TextLength(Text value)
 
 Length in chars of a text value.
 
+
 ## TextLeft
 
 ```kdic-api-docs

--- a/docs/api-docs/kdic/time-rules.md
+++ b/docs/api-docs/kdic/time-rules.md
@@ -1,9 +1,14 @@
 # Time Rules
-`Time` values are encoded in data table files using Khiops native format `HH:MM:SS.`. Other formats
-are available, that allow to convert categorical values to time values. The `.` at the end of the
-format means that fractions of seconds are optional. The use of parenthesis in time formats means
+`Time` values are encoded in data table files using Khiops native format `HH:MM:SS.`,
+or an alternative format specified by the
+`TimeFormat` meta-data (see [`Meta-data`](../kdic/dictionary-files.md/#meta-data)).
+
+The `.` at the end of the format means that fractions of seconds are optional. The use of parenthesis in time formats means
 that the corresponding digit is optional when it is null (e.g. `9:30:8` with format `(H)H:(M)M:(S)S`
 corresponds to `09:30:08` with format `HH:MM:SS`):
+
+
+All available formats are described below:
 
 |                  |                   |             |
 | ---------------- | ----------------- | ----------- |

--- a/docs/api-docs/kdic/timestamp-rules.md
+++ b/docs/api-docs/kdic/timestamp-rules.md
@@ -1,7 +1,9 @@
 # Timestamp Rules
 
-`Timestamp` values are encoded in data table files using Khiops native format `YYYY-MM-DD HH:MM:SS.`.
-Other formats are available, that allow to convert categorical values to timestamp values:
+`Timestamp` values are encoded in data table files using Khiops native format `YYYY-MM-DD HH:MM:SS.`, 
+or an alternative format specified by the `TimestampFormat` meta-data (see [`Meta-data`](../kdic/dictionary-files.md/#meta-data)).
+
+All available formats are described below:
 
 - `<Date format> <Time format>`: A date format followed by a blank and a time format
 - `<Date format>-<Time format>`: A date format followed by a `-` and a time format

--- a/docs/api-docs/kdic/timestamp-tz-rules.md
+++ b/docs/api-docs/kdic/timestamp-tz-rules.md
@@ -1,7 +1,8 @@
 # TimestampTZ Rules
 
 `TimestampTZ` values are encoded in data table files using Khiops native format
-`YYYY-MM-DD HH:MM:SS.zzzzzz`.
+`YYYY-MM-DD HH:MM:SS.zzzzzz`, or an alternative format specified by the
+`TimestampTZFormat` meta-data (see [`Meta-data`](../kdic/dictionary-files.md/#meta-data)).
 
 `TimestampTZ` values consist of a local timestamp value together with time zone information, using
 the ISO 8601 time zone format:

--- a/docs/ui-docs/khiops.md
+++ b/docs/ui-docs/khiops.md
@@ -567,15 +567,16 @@ The values in the data table file are parsed in order to guess their type.
 
 - values with format YYYY-MM-DD HH:MM:SS.zzzzzz are recognized as TimestampTZ variables, with time zone information,
 
-- for other Date, Time, Timestamp or TimestampTZ formats (e.g. Date format DD/MM/YYYY), a specific meta-data value is used (see paragraph 3.2.2. Dictionary) to specify the format used for the variable,
+- for other Date, Time, Timestamp or TimestampTZ formats (e.g. Date format DD/MM/YYYY), 
+  a specific meta-data value is used (see [`Meta-data`](../api-docs/kdic/dictionary-files.md/#meta-data)) to specify the format used for the variable,
+
+    - DateFormat: see [`Date rules`](../api-docs/kdic/date-rules.md)
   
-  - DateFormat: see [`Date rules`](../api-docs/kdic/date-rules.md)
+    - TimeFormat: see [`Time rules`](../api-docs/kdic/time-rules.md)
   
-  - TimeFormat: see [`Time rules`](../api-docs/kdic/time-rules.md)
+    - TimestampFormat: see [`Timestamp rules`](../api-docs/kdic/timestamp-rules.md) 
   
-  - TimestampFormat: see [`Timestamp rules`](../api-docs/kdic/timestamp-rules.md) 
-  
-  - TimestampTZFormat: see [`TimestampTZ rules`](../api-docs/kdic/timestamp-tz-rules.md)
+    - TimestampTZFormat: see [`TimestampTZ rules`](../api-docs/kdic/timestamp-tz-rules.md)
 
 - other values with numerical format are recognized as Numerical values,
 


### PR DESCRIPTION
TableAtKey:
- indiquer que c'est la premiere entite qui match

EntitySet:
- indiquer que l'on ne prend en compte que les entites qui existent, et qu'il n'y aura pas de doublons

HashmapC
- mauvais titre (Structure, au lieu de HashmapC)

Autres corrections dans la documentation:
- https://khiops.org/ui-docs/khiops/#build-dictionary-from-data-table
  - reference "(see paragraph 3.2.2. Dictionary)" a actualiser en format mark down, avec https://khiops.org/api-docs/kdic/dictionary-files/#meta-data
  - DateFormat, TimeFormat,...: parler des meta-data concernes dans les regles
    - exemple: au debut de https://khiops.org/api-docs/kdic/date-rules/, parler du meta-data <DateFormat="YYYY-MM-DD">
      avec reference a https://khiops.org/api-docs/kdic/dictionary-files/#meta-data, plus format par defaut