### PR TITLE
Document the Azure storage driver, update the installation method via `pip` and re-organize the TOCs accordingly

### DIFF
--- a/docs/setup/conda.md
+++ b/docs/setup/conda.md
@@ -4,7 +4,7 @@
 
 # Install the Khiops Library Using Conda 
 
-The Conda package installation guarantees optimal performance since it handles installing or upgrading all Khiops dependencies, including the MPI library, in your Conda environment. 
+The Conda package supports the installation and upgrade of all Khiops dependencies, including the MPI library, in your Conda environment. 
 
 ## Instructions
 
@@ -25,6 +25,8 @@ Once the environment is activated, **you can install Khiops as follow**:
 ```sh
 conda install -c conda-forge khiops={{ CONDA_KHIOPS_PYTHON_VERSION }}
 ```
+
+If you intend to use remote resources while working with the Khiops Library you will have to install additional dependencies ([**vendors SDK and Khiops drivers**](../drivers-and-vendors-python-sdk)).
 
 <br>
 

--- a/docs/setup/drivers-and-vendors-python-sdk.md
+++ b/docs/setup/drivers-and-vendors-python-sdk.md
@@ -4,65 +4,98 @@ Khiops can read and write remote files for the following storage types : **AWS S
 
 ## Khiops drivers
 
-- **Drivers under pip**:
+=== "Pip packages"
   
-  They can be installed on all platforms (supported Linux distributions, Mac OS and Windows).
-  ```commandline
-  # In a Python virtual environment
+    They can be installed on all platforms (supported Linux distributions, Mac OS and Windows).
+    ```commandline
+        # In a Python virtual environment
+     
+        pip install khiops-driver-s3 khiops-driver-gcs khiops-driver-azure
+    ```
+
+=== "Conda packages"
+
+    They can be installed on platforms where Conda can be used
+    ```commandline
+        # In a Conda virtual environment ("conda_env" in the example)
+    
+        conda install -y -n conda_env \
+        khiops-driver-s3=={{ KHIOPS_S3_DRIVER_VERSION }} \
+        khiops-driver-gcs=={{ KHIOPS_GCS_DRIVER_VERSION }} \
+        khiops-driver-azure=={{ KHIOPS_AZURE_DRIVER_VERSION }} 
+    ```
+
+=== "System packages"
+  
+    They can be installed on the supported Linux distributions only
+
+    !!! info "Supported Linux distributions" 
+        - Rocky Linux 9
+        - Debian 11, 12 and 13
+        - Ubuntu 20.04, 22.04 and 24.04 (LTS) on x86-64 architectures
+        - Ubuntu 22.04 and 24.04 (LTS) on ARM architectures.
+
+    *Ubuntu / Debian*
+    ```commandline
+        if [ -f /etc/os-release ]; then . /etc/os-release; fi && \
+        wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb && \
+        wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb && \
+        wget -O khiops-azure.deb https://github.com/KhiopsML/khiopsdriver-azure/releases/download/{{ KHIOPS_AZURE_DRIVER_VERSION }}/khiops-driver-azure_{{ KHIOPS_AZURE_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb && \
+        (sudo dpkg -i --force-all khiops-gcs.deb khiops-s3.deb khiops-azure.deb || true) && \
+        sudo apt-get -f -y install && \
+        rm -f khiops-gcs.deb khiops-s3.deb khiops-azure.deb
+    ```
+    *Rocky Linux*
+    ```commandline
+          ROCKY_VERSION=$(rpm -E %{rhel}) && \  
+          wget -O khiops-gcs.rpm "https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
+          wget -O khiops-s3.rpm "https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
+          wget -O khiops-azure.rpm "https://github.com/KhiopsML/khiopsdriver-azure/releases/download/{{ KHIOPS_AZURE_DRIVER_VERSION }}/khiops-driver-azure_{{ KHIOPS_AZURE_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
+          sudo yum install  -y && \
+          rm -f khiops-gcs.rpm khiops-s3.rpm khiops-azure.rpm
+    ```
+
+## The Khiops Python library additional dependencies
+
+If you intend to use remote resources while working with the Khiops Library you will have to install additional dependencies:
+
+    - the aformentioned Khiops drivers
+    - a vendor-specific Python SDK
+
+=== "Pip packages"
+
+    This can be done in one step during the [**pip installation**](../pip) of the Khiops Python library.
+    
+    ```commandline
+      pip install khiops[s3] # for a specific storage type only
+      pip install khiops[s3,gcs,azure] # for all the supported storage types
+    ```
+
+=== "Conda packages"
  
-  pip install khiops-driver-s3 khiops-driver-gcs khiops-driver-azure
-  ```
+    For s3
+    ```commandline
+    # In a Conda virtual environment ("conda_env" in the example)
+    
+    conda install -y -n conda_env \
+        "boto3>=1.17.39,<=1.35.69" "khiops-driver-s3"
+    ```
 
-- **Drivers under Conda**:
+    For gcs
+    ```commandline
+    # In a Conda virtual environment ("conda_env" in the example)
 
-  They can be installed on platforms where Conda can be used
-  ```commandline
-  # In a Conda virtual environment ("conda_env" in the example)
+    conda install -y -n conda_env \
+        "google-cloud-storage>=1.37.0" "khiops-driver-gcs"
+    ```
 
-  conda install -y -n conda_env \
-  khiops-driver-s3=={{ KHIOPS_S3_DRIVER_VERSION }} \
-  khiops-driver-gcs=={{ KHIOPS_GCS_DRIVER_VERSION }} \
-  khiops-driver-azure=={{ KHIOPS_AZURE_DRIVER_VERSION }} 
-  ```
+    For azure
+    ```commandline
+    # In a Conda virtual environment ("conda_env" in the example)
 
-- **Drivers as system packages**:
-  
-  They can be installed on the supported Linux distributions only
-
-!!! info "Supported Linux distributions" 
-    - Rocky Linux 9
-    - Debian 11, 12 and 13
-    - Ubuntu 20.04, 22.04 and 24.04 (LTS) on x86-64 architectures
-    - Ubuntu 22.04 and 24.04 (LTS) on ARM architectures.
-
-  *Ubuntu / Debian*
-  ```commandline
-    if [ -f /etc/os-release ]; then . /etc/os-release; fi \
-    && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb \
-    && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb \    
-    && wget -O khiops-azure.deb https://github.com/KhiopsML/khiopsdriver-azure/releases/download/{{ KHIOPS_AZURE_DRIVER_VERSION }}/khiops-driver-azure_{{ KHIOPS_AZURE_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb \
-    && (sudo dpkg -i --force-all khiops-gcs.deb khiops-s3.deb khiops-azure.deb || true) \
-    && sudo apt-get -f -y install \
-    && rm -f khiops-gcs.deb khiops-s3.deb khiops-azure.deb
-  ```
-  *Rocky Linux*
-  ```commandline
-  ROCKY_VERSION=$(rpm -E %{rhel}) && \  
-  wget -O khiops-gcs.rpm "https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
-  wget -O khiops-s3.rpm "https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
-  wget -O khiops-azure.rpm "https://github.com/KhiopsML/khiopsdriver-azure/releases/download/{{ KHIOPS_AZURE_DRIVER_VERSION }}/khiops-driver-azure_{{ KHIOPS_AZURE_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
-  sudo yum install  -y && \
-  rm -f khiops-gcs.rpm khiops-s3.rpm khiops-azure.rpm
-  ```
-
-## The Khiops Python library additional dependencies (vendors SDK for Python)
-
-If you are using the Khiops Python library you will have to install a vendor-specific SDK.
-
-This can be done during the [**installation**](../pip) of the Khiops Python library.
-
-```commandline
-  pip install khiops[s3] # for a specific storage type only
-  pip install khiops[s3,gcs,azure] # for all the supported storage types
-```
-
+    conda install -y -n conda_env \
+        "azure-core>=1.39.0,<2.0.0" \
+        "azure-storage-blob>=12.28.0,<13.0.0" \
+        "azure-storage-file-share>=12.24.0,<13.0.0" \
+        "khiops-driver-azure"
+    ```

--- a/docs/setup/drivers-and-vendors-python-sdk.md
+++ b/docs/setup/drivers-and-vendors-python-sdk.md
@@ -1,0 +1,68 @@
+# Installation of remote files drivers and vendors SDK
+
+Khiops can read and write remote files for the following storage types : **AWS S3, Google Cloud Storage (GCS) and Azure**, right after the installation of a few prerequisites.
+
+## Khiops drivers
+
+- **Drivers under pip**:
+  
+  They can be installed on all platforms (supported Linux distributions, Mac OS and Windows).
+  ```commandline
+  # In a Python virtual environment
+ 
+  pip install khiops-driver-s3 khiops-driver-gcs khiops-driver-azure
+  ```
+
+- **Drivers under Conda**:
+
+  They can be installed on platforms where Conda can be used
+  ```commandline
+  # In a Conda virtual environment ("conda_env" in the example)
+
+  conda install -y -n conda_env \
+  khiops-driver-s3=={{ KHIOPS_S3_DRIVER_VERSION }} \
+  khiops-driver-gcs=={{ KHIOPS_GCS_DRIVER_VERSION }} \
+  khiops-driver-azure=={{ KHIOPS_AZURE_DRIVER_VERSION }} 
+  ```
+
+- **Drivers as system packages**:
+  
+  They can be installed on the supported Linux distributions only
+
+!!! info "Supported Linux distributions" 
+    - Rocky Linux 9
+    - Debian 11, 12 and 13
+    - Ubuntu 20.04, 22.04 and 24.04 (LTS) on x86-64 architectures
+    - Ubuntu 22.04 and 24.04 (LTS) on ARM architectures.
+
+  *Ubuntu / Debian*
+  ```commandline
+    if [ -f /etc/os-release ]; then . /etc/os-release; fi \
+    && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb \
+    && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb \    
+    && wget -O khiops-azure.deb https://github.com/KhiopsML/khiopsdriver-azure/releases/download/{{ KHIOPS_AZURE_DRIVER_VERSION }}/khiops-driver-azure_{{ KHIOPS_AZURE_DRIVER_VERSION }}-1-${VERSION_CODENAME}.amd64.deb \
+    && (sudo dpkg -i --force-all khiops-gcs.deb khiops-s3.deb khiops-azure.deb || true) \
+    && sudo apt-get -f -y install \
+    && rm -f khiops-gcs.deb khiops-s3.deb khiops-azure.deb
+  ```
+  *Rocky Linux*
+  ```commandline
+  ROCKY_VERSION=$(rpm -E %{rhel}) && \  
+  wget -O khiops-gcs.rpm "https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
+  wget -O khiops-s3.rpm "https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
+  wget -O khiops-azure.rpm "https://github.com/KhiopsML/khiopsdriver-azure/releases/download/{{ KHIOPS_AZURE_DRIVER_VERSION }}/khiops-driver-azure_{{ KHIOPS_AZURE_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
+  sudo yum install  -y && \
+  rm -f khiops-gcs.rpm khiops-s3.rpm khiops-azure.rpm
+  ```
+
+## The Khiops Python library additional dependencies (vendors SDK for Python)
+
+If you are using the Khiops Python library you will have to install a vendor-specific SDK.
+
+This can be done during the [**installation**](../pip) of the Khiops Python library.
+
+```commandline
+  pip install khiops[s3] # for a specific storage type only
+  pip install khiops[s3,gcs,azure] # for all the supported storage types
+```
+

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -29,7 +29,7 @@ Khiops supports a diversified set of installation options, to meet different nee
     - Ubuntu 22 and 24 (LTS) on ARM architectures
     - Debian 11, 12 and 13
     - Rocky Linux 8, 9 and 10
-    - macOS 12 or later, only via :simple-anaconda: **Conda**. Full support for macOS 13 or later on ARM architectures, limited support for macOS 12 or for x86-64 architectures.
+    - macOS 12 or later. Full support for macOS 13 or later on ARM architectures, limited support for macOS 12 or for x86-64 architectures.
 
     The :simple-googlecolab: **Google Colaboratory** environments are supported. To benefit from Khiops on these environments, users are encouraged to install the Khiops :simple-anaconda:**Conda** package, which has been tested in these environments.
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -11,13 +11,15 @@ hide:
 Khiops supports a diversified set of installation options, to meet different needs:
 
   - **Khiops Python Library**:
-    - Packaged via [`conda`][conda_page] (recommended)
-    - Packaged via [`pip`][pip_page]
+    - Packaged via [`pip`][pip_page] (recommended)
+    - Packaged via [`conda`][conda_page] 
     - Packaged in our [khiops-notebook][notebooks_page] container
   - **Applications**:
     - [**Khiops Application**][nocode] for advanced data analytics with just a few clicks using a graphical user interface. This application is also the basis for easy integration into different systems (all programming languages, docker, servers, etc.).
     - [**Khiops Visualization**][vis]: for intuitive visualization of all analysis results (**interactive demo available [here][demo-vis]**)
     - [**Khiops Native Interface (KNI)**][kni]: to deploy Khiops models with a lightweight shared library.
+  - **Cloud storage drivers and vendors Python SDKs**
+    - [**Drivers & Python SDKs**](drivers-and-vendors-python-sdk) 
 
 !!! warning "Supported Platforms"
     We support :simple-python: **Python from 3.10 to 3.14** on the following operating systems:

--- a/docs/setup/pip.md
+++ b/docs/setup/pip.md
@@ -3,60 +3,43 @@
 {% set ROCKY_KHIOPS_VERSION = KHIOPS_VERSION.replace("-", "_") %}
 -->
 
-# Install the Khiops Library Using Pip <small> :tools: For Advanced users :tools: </small>
+# Install the Khiops Library Using Pip
 
-Opting for `pip` is ideal for those with a comprehensive grasp of Python's ecosystem and an understanding of operating system specifics. This approach, while offering adaptability for custom setups, necessitates knowledge of environment setup and dependency handling.
-
-The Khiops executables must be installed as a prerequisite. This also ensures the installation of the appropriate distribution and version of the MPI library.
+The `pip` package supports the installation and upgrade of all Khiops dependencies, including the MPI library, in your virtual environment.
 
 We support :simple-python: **Python from 3.10 to 3.14**. Usage of previous
 versions of Python can be attempted, but there is no support for it.
 
-=== "Ubuntu / Debian (ARM and x86)"
+===  "Linux and macOS"
 
-    You need to download and install the `khiops-core` package (via Apt) and then the Khiops library (via Pip). You can do this through the following shell commands:
+    In a dedicated virtual environment (recommended)
+
     ``` sh
-    sudo apt-get update -y && sudo apt-get install wget -y && \
-    source /etc/os-release && \
-    ARCH=$(dpkg --print-architecture) && \
-    TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi_{{ KHIOPS_VERSION }}-1-${VERSION_CODENAME}.${ARCH}.deb" && \
-    sudo dpkg -i "$TEMP_DEB" || sudo apt-get -f -y install && \
-    rm -f $TEMP_DEB && \
+    python -m venv myvenv python=3.12
+    source myenv/bin/activate
     pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}
     ```
 
 === "Windows"
-    
-    To install the Khiops executables, required for the Khiops Python library to operate, you must first install the Khiops application before executing the `pip` installation command:
 
-    <a href="https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-{{ KHIOPS_VERSION }}-setup.exe">
-        <button class="btn btn-light btn-sm">
-          Download for Windows
-        </button>
-    </a>
-
-    Then, you can run the following Pip command:
+    In a dedicated virtual environment (recommended)
 
     ```sh
+    python -m venv myvenv python=3.12
+    myenv\Scripts\activate.bat
     pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}
     ```
 
-=== "Rocky Linux"
-    The default Python version on Rocky Linux 8 is 3.6, which does not meet our requirements (at least Python 3.10), **please ensure a compatible Python version is installed before continuing**.
+If you intend to use remote resources while working with the Khiops Library you will have to install additional dependencies ([**vendors SDK and Khiops drivers**](../drivers-and-vendors-python-sdk)). 
 
-    Then, you need to download and install the `khiops-core` package (via Yum) and then the Khiops library (via Pip). You can do this through the following command:
+This can be performed, still in a dedicated virtual environment as recommended, by specifying the type of remote storage (`s3`, `gcs` or `azure`) in square brackets.
 
-    ```sh
-    sudo yum update -y && sudo yum install wget python3-pip -y && \
-    CENTOS_VERSION=$(rpm -E %{rhel}) && \
-    TEMP_RPM="$(mktemp).rpm" && \
-    wget -O "$TEMP_RPM" "https://github.com/KhiopsML/khiops/releases/download/{{ KHIOPS_VERSION }}/khiops-core-openmpi-{{ ROCKY_KHIOPS_VERSION }}-1.el${CENTOS_VERSION}.x86_64.rpm" && \
-    sudo yum install "$TEMP_RPM" -y && \
-    rm -f $TEMP_RPM && \
-    pip install khiops=={{ PIP_KHIOPS_PYTHON_VERSION }}
-    ```
 
+
+```sh 
+pip install khiops[s3]=={{ PIP_KHIOPS_PYTHON_VERSION }} # for a specific storage type only
+pip install khiops[s3,gcs,azure]=={{ PIP_KHIOPS_PYTHON_VERSION }} # for all the supported storage types
+```
 
 ## User Guide
 
@@ -71,76 +54,13 @@ versions of Python can be attempted, but there is no support for it.
 
 ## What You Should Know
 
-You can consult the limitations or known issues for your operating system:
+??? danger "Pip and Conda Khiops installations **should not be mixed.**"
 
-=== "Users on :simple-linux: Linux"
-    !!! info "Currently, our packages are released on GitHub. In the coming weeks, we will transition to official repositories."
+    If the users wish to switch from a Pip-based installation to a Conda-based installation, they need to deactivate the Python virtual environment Khiops had been installed into, via Pip. Or, if no virtual environment has been used, the users need to uninstall the Khiops Library package:
 
-    ??? tip "Important Note for users upgrading from the pre-10.2.0 versions of the `pyKhiops` package"
-
-        If you are upgrading from a version prior to Khiops 10.2.0, it is essential to first make sure the `pykhiops` package is not installed in your Python environment. This ensures that your upgrade process is smooth and that the new version of Khiops installs without conflicts.
-
-        To uninstall pykhiops, please execute the following command in your terminal or command prompt, in your Python environment (use **admin rights** if necessary):
-
-        ```sh
-        pip uninstall pykhiops -y
-        ```
-    ??? danger "Pip and Conda Khiops installations **should not be mixed.**"
-
-        If the users wish to switch from a Pip-based installation to a Conda-based installation, they need to deactivate the Python virtual environment Khiops had been installed into, via Pip. Or, if no virtual environment has been used, the users need to uninstall the Khiops Python package:
-
-        ``` sh
-        pip uninstall khiops
-        ```
-
-        Even though the Khiops executables would remain installed on the operating system, the Conda-based installation would take precedence over them.
-
-    !!! warning
-        The `khiops-core` binary will install or upgrade the system-wide `MPICH` library on your system. If you depend on another version of `MPICH` for other programs, please prefer an installation using Conda.
-
-    !!! warning
-
-        The installation of Khiops will utilize MPICH version 4.0.3 due to compatibility issues.
-        This is why you need to use a dedicated command:
-        ``` sh
-        conda install -c conda-forge -c khiops khiops
-        ```
-
-        Be aware that this may result in **slower execution times** compared to other platforms. This limitation is expected to be addressed in a future MPICH release.
-
-
-=== "Users on :material-microsoft-windows: Windows"
-    !!! info "Currently, our packages are released on GitHub. In the coming weeks, we will transition to official repositories."
-
-    ??? tip "Important Note for users upgrading from the pre-10.2.0 versions of the `pyKhiops` package"
-
-        If you are upgrading from a version prior to Khiops 10.2.0, it is essential to first make sure the `pykhiops` package is not installed in your Python environment. This ensures that your upgrade process is smooth and that the new version of Khiops installs without conflicts.
-
-        To uninstall pykhiops, please execute the following command in your terminal or command prompt, in your Python environment (use **admin rights** if necessary):
-
-        ```sh
-        pip uninstall pykhiops -y
-        ```
-    ??? danger "Pip and Conda Khiops installations **should not be mixed.**"
-
-        If the users wish to switch from a Pip-based installation to a Conda-based installation, they need to deactivate the Python virtual environment Khiops had been installed into, via Pip. Or, if no virtual environment has been used, the users need to uninstall the Khiops Python package:
-
-        ``` sh
-        pip uninstall khiops
-        ```
-
-        Even though the Khiops executables would remain installed on the operating system, the Conda-based installation would take precedence over them.
-
-    !!! warning
-        On the first run of Khiops, **an MPI-related popup may appear** due to parallel execution sockets; please allow access for optimal functionality.
-    !!! warning
-        The Khiops installer relies on embedded installers for Java and MPI. Antivirus software may remove executable files (.exe, .jar) during installation. In this case, **you should add exceptions to your antivirus software or disable it during installation.**
-    !!! warning
-        The java installer results in a system reboot on some systems (e.g. on Windows Server 2008)
-
-=== "Users on :material-apple: macOS"
-    !!! warning
-        Native packages for the Khiops executables are not yet available for macOS, which means that you cannot install Khiops on macOS using Pip for now. You can use Conda or run our Docker container (x86-64 only).
+    ``` sh
+    pip uninstall khiops
+    ```
 
 <br>
 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -20,7 +20,7 @@ Using Docker to run Khiops offers several advantages:
 You will find two images on dockerhub:
 
 - **khiopsml/khiops-ubuntu**: A minimal installation of Khiops on Ubuntu.
-- **khiopsml/khiops-python**: The same base image with Khiops-Python preinstalled.
+- **khiopsml/khiops-python**: The same base image with the Khiops Python library preinstalled.
  
 ### Basic Usage
 
@@ -41,7 +41,7 @@ This command mounts your current directory (`$PWD`) to `/my_data` in the contain
 
 **Running a Python Script**
 
-Similarly, you can use the Python image to run a Khiops-Python script:
+Similarly, you can use the Python image to run a script from the Khiops Python library:
 
 ```bash
 docker run -v $PWD:/my_volume \

--- a/docs/tutorials/storage.md
+++ b/docs/tutorials/storage.md
@@ -1,77 +1,31 @@
 # Cloud Storage
 
-Khiops seamlessly integrates with cloud storage services, enabling **direct reading and writing of datasets stored in AWS S3 and Google Cloud Storage (GCS)** buckets. By using Khiops dedicated cloud storage drivers, you can process large-scale datasets **without having to manually download or transfer files**, significantly improving efficiency and scalability in cloud-based workflows.
+Khiops seamlessly integrates with cloud storage services, enabling **direct reading and writing** of datasets stored in 
+**AWS S3 buckets, Google Cloud Storage (GCS) buckets and Azure storage (in files and blobs)**. 
+By using Khiops dedicated cloud storage drivers, you can process large-scale datasets **without having to manually download or transfer files**, significantly improving efficiency and scalability in cloud-based workflows.
 
 With these drivers, Khiops treats cloud storage **just like a local filesystem**, meaning that all Khiops commands and workflows remain unchanged—only the dataset paths need to be adjusted.
 
-!!! info "Driver Installation Support"
-    On **Windows** and *macOS*, Khiops drivers are only supported through Conda. If you are using another installation method on these operating systems, consider switching to a Conda environment to enable driver support.
-    On **Linux**, Khiops drivers are supported through both Conda (Python only) and by using the native binary installation method (compatible with the [Khiops Application][nocode] and Python via pip). For native installation of the S3 and GCS drivers on Linux, the following operating systems are supported:
-    - Rocky Linux 9
-    - Debian 11, 12 and 13
-    - Ubuntu 20.04, 22.04 and 24.04 (LTS) on x86-64 architectures
-    - Ubuntu 22.04 and 24.04 (LTS) on ARM architectures.
-
-[nocode]: ../setup/nocode.md
+Refer to the specific [installation section](../../setup/drivers-and-vendors-python-sdk) if needed. The current section documents the usage of the remote file storage facilities. 
 
 ## Using Khiops with Google Cloud Storage (GCS)
 
 Khiops can read and write datasets stored in GCS buckets using the `khiopsdriver-gcs` package. Once configured, you can reference GCS paths directly in Khiops commands, scenarios and the GUI (where applicable) using the format `gs://<bucket-name>/path/to/file.csv`.
 
-### Installation
-
-If you installed Khiops through Conda as recommended, you can install the driver as follows:
-
-```sh
-conda install -c conda-forge khiops-driver-gcs
-```
-
-??? warning "If you installed Khiops using `pip` **on Linux**... "
-    === "Ubuntu / Debian" on x86-64 architectures
-
-        ```sh
-        CODENAME=$(lsb_release -cs) && \
-        TEMP_DEB="$(mktemp)" && \
-        wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1-${CODENAME}.amd64.deb" && \
-        sudo dpkg -i "$TEMP_DEB" && \
-        rm -f $TEMP_DEB
-        ```
-
-    === "Ubuntu / Debian" on ARM architectures
-
-        ```sh
-        CODENAME=$(lsb_release -cs) && \
-        TEMP_DEB="$(mktemp)" && \
-        wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1-${CODENAME}.arm64.deb" && \
-        sudo dpkg -i "$TEMP_DEB" && \
-        rm -f $TEMP_DEB
-        ```
-
-    === "Rocky Linux"
-
-        ```sh
-        sudo yum update -y && sudo yum install wget -y && \
-        ROCKY_VERSION=$(rpm -E %{rhel}) && \
-        TEMP_RPM="$(mktemp).rpm" && \
-        wget -O "$TEMP_RPM" "https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/{{ KHIOPS_GCS_DRIVER_VERSION }}/khiops-driver-gcs_{{ KHIOPS_GCS_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
-        sudo yum install "$TEMP_RPM" -y && \
-        rm -f $TEMP_RPM
-        ```
-
-To verify the installation, run:
+To verify that Khiops can use the remote-storage driver, run:
 
 ```sh
 khiops -s
 ```
 
-You should see an output indicating that the GCS driver is loaded and ready to use for data files following the URI `gs` scheme, as follows:
+You should see an output indicating that the GCS driver is loaded and ready to use for data files following the `gs` URI scheme, as follows:
 
 
 ```sh
 Khiops {{ KHIOPS_VERSION }}
 
-Drivers:
-    GCS driver ({{ KHIOPS_GCS_DRIVER_VERSION }}) for URI scheme 'gs'
+Drivers:  
+	GCS driver ({{ KHIOPS_GCS_DRIVER_VERSION }}) for URI scheme 'gs'	    
 Environment variables:
     None
 Internal environment variables:
@@ -125,51 +79,15 @@ _, model_path = kh.train_predictor(
 
 ## Using Khiops with AWS S3 Storage 
 
-To start using Khiops with your data on S3, install the S3 driver package alongside Khiops. If you installed Khiops through Conda as recommended, you can install the driver as follows:
+To start using Khiops with your data on S3, install the S3 driver package alongside Khiops.
 
-```sh
-conda install -c conda-forge khiops-driver-s3
-```
-
-??? warning "If you installed Khiops using `pip` **on Linux**..."
-    === "Ubuntu / Debian" on x86-64 architectures
-
-        ```sh
-        CODENAME=$(lsb_release -cs) && \
-        TEMP_DEB="$(mktemp)" && \
-        wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1-${CODENAME}.amd64.deb" && \
-        sudo dpkg -i "$TEMP_DEB" && \
-        rm -f $TEMP_DEB
-        ```
-
-    === "Ubuntu / Debian" on ARM architectures
-
-        ```sh
-        CODENAME=$(lsb_release -cs) && \
-        TEMP_DEB="$(mktemp)" && \
-        wget -O "$TEMP_DEB" "https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1-${CODENAME}.arm64.deb" && \
-        sudo dpkg -i "$TEMP_DEB" && \
-        rm -f $TEMP_DEB
-        ```
-
-    === "Rocky Linux"
-
-        ```sh
-        sudo yum update -y && sudo yum install wget -y && \
-        ROCKY_VERSION=$(rpm -E %{rhel}) && \
-        TEMP_RPM="$(mktemp).rpm" && \
-        wget -O "$TEMP_RPM" "https://github.com/KhiopsML/khiopsdriver-s3/releases/download/{{ KHIOPS_S3_DRIVER_VERSION }}/khiops-driver-s3_{{ KHIOPS_S3_DRIVER_VERSION }}-1.el${ROCKY_VERSION}.x86_64.rpm" && \
-        sudo yum install "$TEMP_RPM" -y && \
-        rm -f $TEMP_RPM
-        ```
-
-To verify the installation, run:
+To verify that Khiops can use the remote-storage driver, run:
 
 ```sh
 khiops -s
 ```
 
-You should see an output indicating that the S3 driver is loaded and ready to use for data files following the URI `s3` scheme, as follows:
+You should see an output indicating that the S3 driver is loaded and ready to use for data files following the `s3` URI scheme, as follows:
 
 
 ```sh
@@ -238,6 +156,79 @@ from khiops import core as kh
 dictionary_file_path = "s3://mydatabucket/khiops_samples/Adult/Adult.kdic"
 data_table_path = "s3://mydatabucket/khiops_samples/Adult/Adult.kdic"
 report_path = "s3://mydatabucket/khiops_samples/Adult/AnalysisResults.khj"
+
+# Train the predictor
+_, model_path = kh.train_predictor(
+    dictionary_file_path,
+    "Adult",
+    data_table_path,
+    "class",
+    report_path,
+    max_trees=0,
+)
+```
+
+## Using Khiops with Azure Storage
+
+To start using Khiops with your data on Azure, install the Azure driver package alongside Khiops.
+
+To verify that Khiops can use the remote-storage driver, run:
+
+```sh
+khiops -s
+```
+
+You should see an output indicating that the Azure driver is loaded and ready to use for data files following the `https` URI scheme as used by Azure, as follows:
+
+
+```sh
+Khiops {{ KHIOPS_VERSION }}
+
+Drivers:
+    Azure driver ({{ KHIOPS_AZURE_DRIVER_VERSION }}) for URI scheme 'https'
+Environment variables:
+    None
+Internal environment variables:
+    None
+```
+
+### Authentication
+
+To access data stored in Azure storage Blob containers or File shares, you need valid authentication credentials. 
+Khiops supports all the standard Azure authentication options. However, only the `AZURE_STORAGE_CONNECTION_STRING` environment variable is currently fully operational for every component, from the Khiops executables to the Khiops Python library.
+
+`AZURE_STORAGE_CONNECTION_STRING` contains a list of parameters like the `AccountName`, `AccountKey` and other technical parameters.
+
+**You must always copy / paste its value from the "Azure portal" in the "Security + networking > Access keys" of a "Storage account"** instead of trying to craft a connection string by yourself.
+```sh
+export AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;End" 
+```
+
+### Using Azure URIs in Khiops
+
+Please remember that the Azure paths supported by Khiops can either be, 
+
+- file-oriented : `https://<storage account name>.file.core.windows.net/<share name>/path/to/file.csv` 
+- or blob-oriented : `https://<storage account name>.blob.core.windows.net/<container name>/path/to/file.csv`
+
+They can be used in the desktop application (GUI), Python scripts, or within Khiops scenarios. For example:
+
+**Low-Level Khiops Usage:**
+```sh
+khiops -b -i https://khiopsaccount1.file.core.windows.net/my_share/khiops_samples/scenario.kh
+```
+
+**Python Sample:**
+
+```python
+# Imports
+import os
+from khiops import core as kh
+
+# Set the file URIs
+dictionary_file_path = "https://khiopsaccount1.file.core.windows.net/my_share/khiops_samples/Adult/Adult.kdic"
+data_table_path = "https://khiopsaccount1.file.core.windows.net/my_share/khiops_samples/Adult/Adult.kdic"
+report_path = "https://khiopsaccount1.file.core.windows.net/my_share/khiops_samples/Adult/AnalysisResults.khj"
 
 # Train the predictor
 _, model_path = kh.train_predictor(

--- a/environment.env
+++ b/environment.env
@@ -1,13 +1,14 @@
 # Current versions
-# Notes: 
+# Notes:
 # - KHIOPS_DOC current reference is the commit the workflow is launched from
 # - if KHIOPS_VIZ_VERSION is empty, the version ot the latest release is used
 KHIOPS_VERSION=11.0.0
 KHIOPS_PYTHON_VERSION=11.0.0.3
-# KHIOPS_VIZ_VERSION=11.7.0 # Uncomment and update in case of documented regression in the latest release 
+# KHIOPS_VIZ_VERSION=11.7.0 # Uncomment and update in case of documented regression in the latest release
 KHIOPS_SAMPLES_VERSION=11.0.0
-KHIOPS_GCS_DRIVER_VERSION=0.0.14
-KHIOPS_S3_DRIVER_VERSION=0.0.15
+KHIOPS_GCS_DRIVER_VERSION=0.0.23
+KHIOPS_S3_DRIVER_VERSION=0.0.25
+KHIOPS_AZURE_DRIVER_VERSION=0.0.18
 
 # Other versions
 KHIOPS_DOC_OTHER_REF=dev-v10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,8 +118,8 @@ nav:
   - Installation:
       - setup/index.md
       - Khiops Python Library:
-          - conda: setup/conda.md
           - pip: setup/pip.md
+          - conda: setup/conda.md
           - docker notebook: setup/khiops-notebook.md
       - Applications:
           - Khiops Application: setup/nocode.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,8 +60,9 @@ extra:
   KHIOPS_PYTHON_VERSION: !ENV [KHIOPS_PYTHON_VERSION, 11.0.0.3]
   KHIOPS_SAMPLES_VERSION: !ENV [KHIOPS_SAMPLES_VERSION, 11.0.0]
   KHIOPS_VIZ_VERSION: !ENV [KHIOPS_VIZ_VERSION, 11.3.1]
-  KHIOPS_GCS_DRIVER_VERSION: !ENV [KHIOPS_GCS_DRIVER_VERSION, 0.0.14]
-  KHIOPS_S3_DRIVER_VERSION: !ENV [KHIOPS_S3_DRIVER_VERSION, 0.0.14]
+  KHIOPS_GCS_DRIVER_VERSION: !ENV [KHIOPS_GCS_DRIVER_VERSION, 0.0.23]
+  KHIOPS_S3_DRIVER_VERSION: !ENV [KHIOPS_S3_DRIVER_VERSION, 0.0.25]
+  KHIOPS_AZURE_DRIVER_VERSION: !ENV [KHIOPS_AZURE_DRIVER_VERSION, 0.0.18]
   KHIOPS_PYTHON_API_DOC_URI: api/index.html
   social:
     - icon: fontawesome/brands/github
@@ -124,6 +125,8 @@ nav:
           - Khiops Application: setup/nocode.md
           - Khiops Visualization: setup/visualization.md
           - Khiops Native Interface (KNI): setup/kni.md
+      - Cloud storage drivers and vendors Python SDKs:
+          - Drivers & Python SDKs: setup/drivers-and-vendors-python-sdk.md
   - How to:
       - tutorials/introduction.md
       - Scikit-learn API:


### PR DESCRIPTION
Fixes 
- #93 (vendors SDK used by `khiops-python`)
- #203 (Azure storage type)
- #201 (Full `pip` installation)