### PR TITLE
Improve documentation regarding missing values in logical operators

### DIFF
--- a/docs/api-docs/kdic/logical-operators.md
+++ b/docs/api-docs/kdic/logical-operators.md
@@ -1,7 +1,8 @@
 # Logical Operators
 
-These rules use boolean operands (numerical values with 0 for false and not 0 for true) and return
-boolean values encoded as 0 or 1 numerical values.
+These operators accept any Numerical value as an operand, with zero representing false and any non-zero (including missing values) representing true. The results are always encoded as 0 or 1.
+
+Note that the special value `#Missing` represents a missing value and can be used as a numerical operand in any derivation rule.
 
 ## And
 
@@ -11,6 +12,23 @@ Numerical And(Numerical boolean1, ...)
 
 And logical operator.
 
+!!! example
+
+    ```kdic
+    Dictionary Person
+    {
+      Categorical Name;
+      Numerical Age;
+      Categorical City;
+      // Returns 1 if Age is less than 18 (or missing) and City is "New York", otherwise returns 0
+      Numerical IsSelected1 = And(L(Age, 18), EQ(City, "New York"));
+      // Returns 1 if Age is less than 18 and not missing and City is "New York", otherwise returns 0
+      Numerical IsSelected2 = And(And(L(Age, 18), NEQ(Age, #Missing)), EQ(City, "New York"));
+      // Returns 1 if Age is missing and City is "New York", otherwise returns 0
+      Numerical IsSelected3 = And(EQ(Age, #Missing), EQ(City, "New York"));
+    }
+    ```
+
 ## Or
 
 ```kdic-api-docs
@@ -18,6 +36,24 @@ Numerical Or(Numerical boolean1, ...)
 ```
 
 Or logical operator.
+
+!!! example
+
+    ```kdic
+    Dictionary Person
+    {
+      Categorical Name;
+      Numerical Age;
+      Categorical City;
+      // Returns 1 if Age is less than 18 (or missing) or City is "New York", otherwise returns 0
+      Numerical IsSelected1 = Or(L(Age, 18), EQ(City, "New York"));
+      // Returns 1 if Age is less than 18 and not missing, or City is "New York", otherwise returns 0
+      Numerical IsSelected2 = Or(And(L(Age, 18), NEQ(Age, #Missing)), EQ(City, "New York"));
+      // Returns 1 if Age is missing or City is "New York", otherwise returns 0
+      Numerical IsSelected3 = Or(EQ(Age, #Missing), EQ(City, "New York"));
+    }
+    ```
+
 
 ## Not
 

--- a/docs/api-docs/kdic/numerical-comparisons.md
+++ b/docs/api-docs/kdic/numerical-comparisons.md
@@ -1,8 +1,13 @@
 # Numerical Comparisons
 
-These rules return boolean values encoded as 0 or 1 numerical values. Note that the missing
-value is treated as a value that is inferior to any valid value in comparisons.
 
+These rules evaluate numerical expressions and return boolean results encoded as `0` (false) or `1` (true).
+
+**Important notes:**
+
+- The special value `#Missing` represents a missing value and can be used as a numerical operand in any derivation rule.
+
+- When involved in comparisons, `#Missing` is considered inferior to any valid value.
 
 ## EQ
 
@@ -12,6 +17,21 @@ Numerical EQ(Numerical value1, Numerical value2)
 ```
 
 Equality test between two numerical values.
+
+!!! example
+
+    ```kdic
+    Dictionary Person
+    {
+      Categorical Name;
+      Numerical Age;
+      // Returns 1 if Age is 18, otherwise returns 0
+      Numerical IsAge18 = EQ(Age, 18);
+      // Returns 1 if Age is missing, otherwise returns 0
+      Numerical IsAgeMissing = EQ(Age, #Missing);  
+    }
+    ```
+
 
 ## NEQ
 
@@ -29,6 +49,7 @@ Numerical G(Numerical value1, Numerical value2)
 
 Greater than test between two numerical values.
 
+
 ## GE
 
 ```kdic-api-docs
@@ -37,6 +58,18 @@ Numerical GE(Numerical value1, Numerical value2)
 
 Greater than or equal test between two numerical values.
 
+!!! example
+
+    ```kdic
+    Dictionary Person
+    {
+      Categorical Name;
+      Numerical Age;
+      // Returns 1 if Age is greater than or equal to 18, otherwise returns 0
+      Numerical IsAdult = GE(Age, 18);               
+    }
+    ```
+
 ## L
 
 ```kdic-api-docs
@@ -44,6 +77,21 @@ Numerical L(Numerical value1, Numerical value2)
 ```
 
 Less than test between two numerical values.
+
+!!! example
+
+    ```kdic
+    Dictionary Person
+    {
+      Categorical Name;
+      Numerical Age;
+      // Returns 1 if Age is less than 18 (or missing), otherwise returns 0
+      Numerical IsYoungOrMissing = L(Age, 18);               
+      // Returns 1 if Age is less than 18 and not missing, otherwise returns 0
+      Numerical IsYoung = And(L(Age, 18), NEQ(Age, #Missing)); 
+    }
+    ```
+
 
 ## LE
 


### PR DESCRIPTION
Clarification sur le comportement de la valeur manquante:
- pour les operateurs logiques
- pour les regles de comparaion numerique

Ajout d'exemples